### PR TITLE
fix(rules): file matching syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,13 +52,13 @@ module.exports = {
   },
   overrides: [
     {
-      files: ['*.(tsx|ts)'],
+      files: ['*.{tsx,ts}'],
       rules: {
         "@typescript-eslint/consistent-type-imports": "error"
       }
     },
     {
-      files: ["**/*.stories.(mdx|tsx|js|jsx)"],
+      files: ["**/*.stories.{mdx,tsx,js,jsx}"],
       extends: ["plugin:storybook/recommended"],
     },
     {


### PR DESCRIPTION
This is my bad. 

Always getting the different file matching syntax's wrong. I thought I tested this but has left the TS rule in the main block which is why it worked during the test. 